### PR TITLE
spring-cloud-k8s-gateway to 1.0.17

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
   version: 2.3.58
+- name: spring-cloud-k8s-gateway
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.17
 - name: spring-cloud-k8s-minion
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.56


### PR DESCRIPTION
Promote spring-cloud-k8s-gateway to version 1.0.17