### PR TITLE
spring-cloud-k8s-gateway to 1.0.18

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 1.0.30
 - name: spring-cloud-k8s-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.17
+  version: 1.0.18
 - name: spring-cloud-k8s-minion
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.56


### PR DESCRIPTION
Promote spring-cloud-k8s-gateway to version 1.0.18